### PR TITLE
Update Cargo.toml add repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.3"
 edition = "2021"
 description = "API to manage chromium headless processes."
 license = "MIT"
+repository = "https://github.com/a11ywatch/chrome"
 
 [dependencies]
 hyper = "0.14.27"


### PR DESCRIPTION
to allow crates.io, rust-digger and others to link to it